### PR TITLE
Fix for when Yahoo reports no institutional holders

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -280,10 +280,13 @@ class TickerBase():
         data = utils.get_json(url, proxy)
 
         # holders
-        url = "{}/{}/holders".format(self._scrape_url, self.ticker)
-        holders = _pd.read_html(url)
+        text = utils.get(url+'/holders', proxy)
+        holders = _pd.read_html(text)
         self._major_holders = holders[0]
-        self._institutional_holders = holders[1]
+        if len(holders) > 1:
+            self._institutional_holders = holders[1]
+        else:
+            self._institutional_holders = _pd.DataFrame()
         if 'Date Reported' in self._institutional_holders:
             self._institutional_holders['Date Reported'] = _pd.to_datetime(
                 self._institutional_holders['Date Reported'])

--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -41,12 +41,16 @@ def empty_df(index=[]):
     empty.index.name = 'Date'
     return empty
 
+def get(url, proxy=None, **kwargs):
+    response = _requests.get(url=url, proxies=proxy, **kwargs)
+    response.raise_for_status()
+    return response.text
 
 def get_json(url, proxy=None):
-    html = _requests.get(url=url, proxies=proxy).text
+    html = get(url, proxy)
 
     if "QuoteSummaryStore" not in html:
-        html = _requests.get(url=url, proxies=proxy).text
+        html = get(url, proxy)
         if "QuoteSummaryStore" not in html:
             return {}
 


### PR DESCRIPTION
It's possible for Yahoo to report no institutional holders on some tickers.
For instance, this code works:

```python
import yfinance as yf
ticker = yf.Ticker("ADM.L").institutional_holders
```

Whereas this collapses in a flaming mess:

```python
import yfinance as yf
ticker = yf.Ticker("VOD.L").institutional_holders
```

This patch does two things:

1. It provides a `utils.get()` function to wrap `requests.get()`, ensuring that
we get an exception raised if we get a bad HTTP status code from Yahoo.  That
function is then used in `TickerBase._get_fundamentals()` in preference to
letting `pandas.read_html()` handle the connection.  Having a single place to
change how HTTP requests are performed makes HTTP error handling easier.

2. It checks for `holders[1]` before using it, substituting an empty
`DataFrame` if it's not there.